### PR TITLE
Fix Sophie Adenot image URL

### DIFF
--- a/JSON/people-in-space.json
+++ b/JSON/people-in-space.json
@@ -154,7 +154,7 @@
       "iss": true,
       "days_in_space": 0,
       "url": "https://en.wikipedia.org/wiki/Sophie_Adenot",
-      "image": "https://upload.wikimedia.org/wikipedia/commons/c/cd/Official_portrait_of_ESA_%28European_Space_Agency%29_astronaut_Sophie_Adenot_%28jsc2025e058846_alt%29.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Official_portrait_of_ESA_astronaut_Sophie_Adenot_%28jsc2025e058846_alt%29.jpg/500px-Official_portrait_of_ESA_astronaut_Sophie_Adenot_%28jsc2025e058846_alt%29.jpg",
       "instagram": "https://www.instagram.com/soph_astro",
       "twitter": "https://x.com/Soph_astro",
       "facebook": "https://www.facebook.com/ESASophieAdenot/"


### PR DESCRIPTION
While building https://tonvanbart.github.io/people-in-space-2/ I noticed that on that page the image for Sophie Adenot is missing; if you open the URL in the browser you will get a 404. This PR replaces the image URL with a working one.
Many thanks for the great work btw!